### PR TITLE
Add On-Balance Volume (OBV) Indicator

### DIFF
--- a/backtrader/indicators/__init__.py
+++ b/backtrader/indicators/__init__.py
@@ -76,6 +76,7 @@ from .williams import *
 from .rmi import *
 from .awesomeoscillator import *
 from .accdecoscillator import *
+from .obv import *
 
 
 from .dv2 import *  # depends on percentrank

--- a/backtrader/indicators/obv.py
+++ b/backtrader/indicators/obv.py
@@ -1,0 +1,40 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .indicator import Indicator
+
+
+class OnBalanceVolume(Indicator):
+    """
+    On-Balance Volume (OBV) Indicator
+
+    Formula:
+      OBV[0] = 0 (on the very first bar)
+      If Close[0] > Close[-1] => OBV = OBV[-1] + Volume[0]
+      If Close[0] < Close[-1] => OBV = OBV[-1] - Volume[0]
+      If Close[0] = Close[-1] => OBV = OBV[-1]
+
+    This indicator can be used on daily, weekly, monthly or any other timeframe
+    supported by Backtrader. The "close" price is whatever the data feed (or
+    resampler) provides as the close of that period (e.g., last trading day of
+    the week for weekly data, last trading day of the month for monthly, etc.).
+    """
+    lines = ('obv',)
+
+    def __init__(self):
+        # We want at least 1 previous bar to compare closes
+        self.addminperiod(1)
+
+    def next(self):
+        # Initialize OBV to 0 on the very first bar
+        if len(self) == 1:
+            self.lines.obv[0] = 0
+        else:
+            prev_obv = self.lines.obv[-1]
+            if self.data.close[0] > self.data.close[-1]:
+                self.lines.obv[0] = prev_obv + self.data.volume[0]
+            elif self.data.close[0] < self.data.close[-1]:
+                self.lines.obv[0] = prev_obv - self.data.volume[0]
+            else:
+                # close == close[-1]
+                self.lines.obv[0] = prev_obv

--- a/backtrader/indicators/obv.py
+++ b/backtrader/indicators/obv.py
@@ -1,9 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from .indicator import Indicator
-
-
 class OnBalanceVolume(Indicator):
     """
     On-Balance Volume (OBV) Indicator

--- a/backtrader/indicators/obv.py
+++ b/backtrader/indicators/obv.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-from .indicator import Indicator
+from . import Indicator
 
 class OnBalanceVolume(Indicator):
     """

--- a/backtrader/indicators/obv.py
+++ b/backtrader/indicators/obv.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from .indicator import Indicator
 
 class OnBalanceVolume(Indicator):
     """


### PR DESCRIPTION
This PR adds the On-Balance Volume (OBV) technical indicator to the backtrader library.

## Changes Made:
- Added new `OnBalanceVolume` indicator class in `backtrader/indicators/obv.py`
- Updated `backtrader/indicators/__init__.py` to include the new OBV indicator

## About OBV Indicator:
The On-Balance Volume (OBV) indicator is a momentum indicator that uses volume flow to predict changes in stock price. The OBV is calculated by:
- Adding volume on up days (when close > previous close)
- Subtracting volume on down days (when close < previous close)  
- Keeping OBV unchanged when close equals previous close

## Implementation Details:
- Follows backtrader's indicator conventions
- Supports all timeframes (daily, weekly, monthly, etc.)
- Properly handles initialization with minimum period of 1
- Includes comprehensive docstring with formula explanation

The indicator can be used like any other backtrader indicator for technical analysis and trading strategy development.